### PR TITLE
Allow floats in object bounds

### DIFF
--- a/tmx/tmx.go
+++ b/tmx/tmx.go
@@ -130,10 +130,10 @@ type ObjectGroup struct {
 type Object struct {
 	Name       string     `xml:"name,attr"`
 	Type       string     `xml:"type,attr"`
-	X          int        `xml:"x,attr"`
-	Y          int        `xml:"y,attr"`
-	Width      int        `xml:"width,attr"`
-	Height     int        `xml:"height,attr"`
+	X          float64    `xml:"x,attr"`
+	Y          float64    `xml:"y,attr"`
+	Width      float64    `xml:"width,attr"`
+	Height     float64    `xml:"height,attr"`
 	GID        int        `xml:"gid,attr"`
 	Visible    bool       `xml:"visible,attr"`
 	Polygons   []Polygon  `xml:"polygon"`


### PR DESCRIPTION
Objects often have float values as position, with or height, so it's necessary to decode them as floats